### PR TITLE
Unused package remove

### DIFF
--- a/go_jolokia.go
+++ b/go_jolokia.go
@@ -7,7 +7,6 @@ package go_jolokia
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"


### PR DESCRIPTION
Please remove "errors", because package doesn't compile (and "go get" hence) with unused imports.
